### PR TITLE
New model of stellar tidal stripping implemented

### DIFF
--- a/doc/hdf5_properties/galaxies.rst
+++ b/doc/hdf5_properties/galaxies.rst
@@ -60,6 +60,10 @@
 * ``mstars_metals_burst_diskinstabilities``: mass of metals locked in stars that formed via starbursts driven by disk instabilities [Msun/h]
 * ``mstars_metals_burst_mergers``: mass of metals locked in stars that formed via starbursts driven by galaxy mergers [Msun/h]
 * ``mstars_metals_disk``: mass of metals locked in stars in the disk [Msun/h]
+* ``mstars_metals_tidally_stripped``: mass of metals locked in stars that was tidally stripped from this galaxy [Msun/h]
+* ``mstars_tidally_stripped``: stellar mass that was tidally stripped from this galaxy [Msun/h]
+* ``mstellar_halo``: stellar mass in the halo built by tidal stripping [Msun/h]
+* ``mstellar_halo_metals``: mass of metals locked up in the stellar halo built by tidal stripping [Msun/h]
 * ``mvir_hosthalo``: Dark matter mass of the host halo in which this galaxy resides [Msun/h]
 * ``mvir_subhalo``: Dark matter mass of the subhalo in which this galaxy resides [Msun/h]. In the case of type 2 satellites, this corresponds to the mass its subhalo had before disappearing from the subhalo catalogs.
 * ``position_x``: position component x of galaxy [cMpc/h]. In the case of type 2 galaxies, the positions are generated to randomly sample an NFW halo with the concentration of the halo the galaxy lives in.

--- a/include/environment.h
+++ b/include/environment.h
@@ -42,6 +42,8 @@ public:
 
 	bool gradual_stripping = false;
 	bool stripping = true;
+	bool tidal_stripping = false;
+	float minimum_halo_mass_fraction = 0.01;
 
 };
 
@@ -51,10 +53,12 @@ public:
 	explicit Environment(const EnvironmentParameters &parameters);
 
 	void process_satellite_subhalo_environment (Subhalo &satellite_subhalo, Subhalo &central_subhalo);
+	void remove_tidal_stripped_stars(Galaxy &galaxy, float lost_stellar_mass, float lost_stellar_mass_metals);
 
 private:
 
 	EnvironmentParameters parameters;
+
 };
 
 using EnvironmentPtr = std::shared_ptr<Environment>;

--- a/include/galaxy.h
+++ b/include/galaxy.h
@@ -142,7 +142,8 @@ public:
 	float vvir_type2 = 0;
 	/// subhalo spin parameter of this galaxy before it became type 2, only relevant for type 2 galaxies
 	float lambda_type2 = 0;
-
+	/// tracking of mass lost due to tidal stripping
+	BaryonBase stars_tidal_stripped;
 	/// The ID of the descendant of this galaxy, -1 if no descendant is defined
 	id_t descendant_id = -1;
 	/// The type of this galaxy

--- a/include/subhalo.h
+++ b/include/subhalo.h
@@ -218,6 +218,9 @@ public:
 	float lambda = 0;
 	/// redshift at which the subhalo became a type > 0.
 	float infall_t = 0;
+	/// halo mass and stellar mass of central galaxy at infall_t;
+	float Mvir_infall = 0;
+	BaryonBase star_central_infall;
 	/// The accreted baryonic mass onto the subhalo. This information comes from the merger tree
 	float accreted_mass = 0;
 	/// information of the virial temperature, total halo gas and cooling time history.
@@ -230,6 +233,8 @@ public:
 	RotatingBaryonBase ejected_galaxy_gas;
 	/// Lost gas reservoir which tracks the gas that is outflowing due to QSO feedback and that has escaped the halo.
 	BaryonBase lost_galaxy_gas;
+	/// Intra-halo stellar component - produced by tidal interactions of satellites with halo.
+	BaryonBase stellar_halo;
 	/// The snapshot at which this subhalo is found
 	int snapshot;
 	/// The snapshot at which the descendant of this subhalo can be found

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -22,13 +22,17 @@
 
 #include "environment.h"
 #include "subhalo.h"
+#include "galaxy.h"
 
 namespace shark {
 
 EnvironmentParameters::EnvironmentParameters(const Options &options)
 {
-	options.load("environment.gradual_stripping", gradual_stripping);
 	options.load("environment.stripping", stripping, true);
+	options.load("environment.gradual_stripping", gradual_stripping);
+	options.load("environment.tidal_stripping", tidal_stripping);
+	options.load("environment.minimum_halo_mass_fraction", minimum_halo_mass_fraction);
+
 }
 
 Environment::Environment(const EnvironmentParameters &parameters):
@@ -46,6 +50,7 @@ void Environment::process_satellite_subhalo_environment(Subhalo &satellite_subha
 	satellite_subhalo.ejected_galaxy_gas.restore_baryon();
 	satellite_subhalo.lost_galaxy_gas.restore_baryon();
 
+
 	// Remove hot halo gas only if stripping is applied
 	if(parameters.stripping){
 
@@ -62,7 +67,88 @@ void Environment::process_satellite_subhalo_environment(Subhalo &satellite_subha
 				satellite_subhalo.cold_halo_gas.restore_baryon();
 			}
 		}
+
 	}
+
+	// Remove part of the stellar content of satellite if relevant.
+	// Cases to consider:
+	// 1. A satellite subhalo that has a central galaxy type=1
+	// 2. A satellite subhalo that does not have a central. In this case we have to check the type II satellites
+	// in the halo of the central to see if they have been stripped accordingly.
+	if(parameters.tidal_stripping){
+		float ratio_mass_thresh = 0.01;
+		if(satellite_subhalo.central_galaxy()){
+			// Apply here model of Errani et al. (2015).
+			float ratio_mass = satellite_subhalo.Mvir / satellite_subhalo.Mvir_infall;
+			// Apply a maximum stripping of 99% in halo mass.
+			if(ratio_mass < ratio_mass_thresh){
+				ratio_mass = ratio_mass_thresh;
+			}
+
+			// compute how much has been lost since galaxy infall
+			float ratio_sm = std::pow(2, 3.43) * std::pow(ratio_mass, 1.86) / std::pow( 1 + ratio_mass, 3.43);
+			float lost_stellar_mass = (1 - ratio_sm) * satellite_subhalo.star_central_infall.mass;
+			float lost_stellar_mass_metals = (1 - ratio_sm) * satellite_subhalo.star_central_infall.mass_metals;
+			// now remove what has already been lost in previous snapshots to compute what should be subtracted from
+			// the central galaxy in the satellite subhalo now.
+			lost_stellar_mass = lost_stellar_mass - satellite_subhalo.central_galaxy()->stars_tidal_stripped.mass;
+			lost_stellar_mass_metals = lost_stellar_mass_metals - satellite_subhalo.central_galaxy()->stars_tidal_stripped.mass_metals;
+
+			if(lost_stellar_mass > 0 && lost_stellar_mass_metals > 0){
+				remove_tidal_stripped_stars(*satellite_subhalo.central_galaxy(), lost_stellar_mass, lost_stellar_mass_metals);
+
+				// add the stripped material to central subhalo
+				central_subhalo.stellar_halo.mass += lost_stellar_mass;
+				central_subhalo.stellar_halo.mass_metals += lost_stellar_mass_metals;
+			}
+		}
+		// check all type 2 galaxies in the central subhalo.
+		if(central_subhalo.type2_galaxies_count() > 0){
+			float ratio_sm = std::pow(2, 3.43) * std::pow(ratio_mass_thresh, 1.86) / std::pow( 1 + ratio_mass_thresh, 3.43);
+			// in this case loop over type II satellites and if they have not been stripped
+			// then strip a fraction of the satellite mass.
+			for (auto &satellite: central_subhalo.type2_galaxies() ){
+				// If no stripping has occured in this type II then assume 99% loss of DM.
+				// is stars_tidal_stripped.mass>0 is because stripping should have occured already.
+				if(satellite.stars_tidal_stripped.mass == 0){
+					// compute how much has been lost since galaxy infall
+					float lost_stellar_mass = (1 - ratio_sm) * satellite.stellar_mass();
+					float lost_stellar_mass_metals = (1 - ratio_sm) * satellite.stellar_mass_metals();
+
+					remove_tidal_stripped_stars(satellite, lost_stellar_mass, lost_stellar_mass_metals);
+
+					// add the stripped material to central subhalo
+					central_subhalo.stellar_halo.mass += lost_stellar_mass;
+					central_subhalo.stellar_halo.mass_metals += lost_stellar_mass_metals;
+				}
+			}
+		}
+	}
+
+}
+
+void Environment::remove_tidal_stripped_stars(Galaxy &galaxy, float lost_stellar_mass, float lost_stellar_mass_metals){
+
+
+	//check that lost mass does not exceed the total stellar mass of the galaxy to be stripped.
+	if(lost_stellar_mass > galaxy.stellar_mass()){
+		lost_stellar_mass = galaxy.stellar_mass();
+		lost_stellar_mass_metals = galaxy.stellar_mass_metals();
+		galaxy.disk_stars.restore_baryon();
+		galaxy.bulge_stars.restore_baryon();
+	}
+	else{
+		// define bulge-to-total ratio.
+		float bulge_disk_gal = galaxy.bulge_stars.mass / galaxy.stellar_mass();
+		// remove stellar mass and metals in proportion to the disk and bulge stellar mass contributions.
+		galaxy.disk_stars.mass -= (1 - bulge_disk_gal) * lost_stellar_mass;
+		galaxy.disk_stars.mass_metals -= (1 - bulge_disk_gal) * lost_stellar_mass_metals;
+		galaxy.bulge_stars.mass -= bulge_disk_gal * lost_stellar_mass;
+		galaxy.bulge_stars.mass_metals -= bulge_disk_gal * lost_stellar_mass_metals;
+	}
+	// accummulate what has been lost to tidal stripping in this galaxy.
+	galaxy.stars_tidal_stripped.mass += lost_stellar_mass;
+	galaxy.stars_tidal_stripped.mass_metals += lost_stellar_mass_metals;
 
 }
 

--- a/src/evolve_halos.cpp
+++ b/src/evolve_halos.cpp
@@ -44,6 +44,13 @@ void adjust_main_galaxy(const SubhaloPtr &parent, const SubhaloPtr &descendant)
 	auto is_main_progenitor = parent->main_progenitor;
 	auto main_galaxy = (parent_is_central ? parent->central_galaxy() : parent->type1_galaxy());
 
+	// Define the stellar content of the central at the moment of infall. So this applied only to subhalos that are currently centrail but will become
+	// satellite in the next snapshot.
+	if(parent_is_central && !desc_is_central){
+		descendant->star_central_infall.mass = main_galaxy->stellar_mass();
+		descendant->star_central_infall.mass_metals = main_galaxy->stellar_mass_metals();
+	}
+
 	if (!main_galaxy) {
 		return;
 	}

--- a/src/galaxy_writer.cpp
+++ b/src/galaxy_writer.cpp
@@ -199,6 +199,7 @@ void HDF5GalaxyWriter::write_galaxies(hdf5::Writer &file, int snapshot, const st
 	vector<float> mstars_burst_diskinstabilities;
 	vector<float> mstars_bulge_mergers_assembly;
 	vector<float> mstars_bulge_diskins_assembly;
+	vector<float> mstars_stripped;
 	vector<float> mgas_disk;
 	vector<float> mgas_bulge;
 	vector<float> mstars_metals_disk;
@@ -207,6 +208,7 @@ void HDF5GalaxyWriter::write_galaxies(hdf5::Writer &file, int snapshot, const st
 	vector<float> mstars_metals_burst_diskinstabilities;
 	vector<float> mstars_metals_bulge_mergers_assembly;
 	vector<float> mstars_metals_bulge_diskins_assembly;
+	vector<float> mstars_metals_stripped;
 	vector<float> mgas_metals_disk;
 	vector<float> mgas_metals_bulge;
 	vector<float> mmol_disk;
@@ -241,6 +243,9 @@ void HDF5GalaxyWriter::write_galaxies(hdf5::Writer &file, int snapshot, const st
 
 	vector<float> mreheated;
 	vector<float> mreheated_metals;
+
+	vector<float> stellar_halo;
+	vector<float> stellar_halo_metals;
 
 	vector<float> mlost;
 	vector<float> mlost_metals;
@@ -322,6 +327,7 @@ void HDF5GalaxyWriter::write_galaxies(hdf5::Writer &file, int snapshot, const st
 			auto cold_subhalo = subhalo->cold_halo_gas;
 			auto reheated_subhalo = subhalo->ejected_galaxy_gas;
 			auto lost_subhalo = subhalo->lost_galaxy_gas;
+			auto stellarhalo = subhalo->stellar_halo;
 
 			descendant_id.push_back(subhalo->descendant_id);
 			infall_time_subhalo.push_back(subhalo->infall_t);
@@ -357,7 +363,7 @@ void HDF5GalaxyWriter::write_galaxies(hdf5::Writer &file, int snapshot, const st
 				mstars_bulge_mergers_assembly.push_back(galaxy.galaxymergers_assembly_stars.mass);
 				mstars_burst_diskinstabilities.push_back(galaxy.diskinstabilities_burst_stars.mass);
 				mstars_bulge_diskins_assembly.push_back(galaxy.diskinstabilities_assembly_stars.mass);
-
+				mstars_stripped.push_back(galaxy.stars_tidal_stripped.mass);
 				mean_stellar_age.push_back(galaxy.mean_stellar_age / galaxy.total_stellar_mass_ever_formed);
 
 				// Gas components
@@ -371,6 +377,7 @@ void HDF5GalaxyWriter::write_galaxies(hdf5::Writer &file, int snapshot, const st
 				mstars_metals_bulge_mergers_assembly.push_back(galaxy.galaxymergers_assembly_stars.mass_metals);
 				mstars_metals_burst_diskinstabilities.push_back(galaxy.diskinstabilities_burst_stars.mass);
 				mstars_metals_bulge_diskins_assembly.push_back(galaxy.diskinstabilities_burst_stars.mass_metals);
+				mstars_metals_stripped.push_back(galaxy.stars_tidal_stripped.mass_metals);
 
 				// Metals of the gas components.
 				mgas_metals_disk.push_back(galaxy.disk_gas.mass_metals);
@@ -406,6 +413,8 @@ void HDF5GalaxyWriter::write_galaxies(hdf5::Writer &file, int snapshot, const st
 				double mzreheat = 0;
 				double lostm = 0;
 				double lostzm = 0;
+				double mstellarhalo = 0;
+				double mzstellarhalo = 0;
 
 				double rcool = 0;
 				int t = galaxy.galaxy_type;
@@ -417,6 +426,8 @@ void HDF5GalaxyWriter::write_galaxies(hdf5::Writer &file, int snapshot, const st
 					lostm = lost_subhalo.mass;
 					lostzm = lost_subhalo.mass_metals;
 					rcool = halo->cooling_rate;
+					mstellarhalo = stellarhalo.mass;
+					mzstellarhalo = stellarhalo.mass_metals;
 				}
 
 				cooling_rate.push_back(rcool);
@@ -427,6 +438,9 @@ void HDF5GalaxyWriter::write_galaxies(hdf5::Writer &file, int snapshot, const st
 				mreheated_metals.push_back(mzreheat);
 				mlost.push_back(lostm);
 				mlost_metals.push_back(lostzm);
+				stellar_halo.push_back(mstellarhalo);
+				stellar_halo_metals.push_back(mzstellarhalo);
+
 
 				mvir_hosthalo.push_back(mhalo);
 				vvir_hosthalo.push_back(vhalo);
@@ -537,6 +551,7 @@ void HDF5GalaxyWriter::write_galaxies(hdf5::Writer &file, int snapshot, const st
 	REPORT(mstars_burst_diskinstabilities);
 	REPORT(mstars_bulge_mergers_assembly);
 	REPORT(mstars_bulge_diskins_assembly);
+	REPORT(mstars_stripped);
 	REPORT(mgas_disk);
 	REPORT(mgas_bulge);
 	REPORT(mstars_metals_disk);
@@ -545,6 +560,7 @@ void HDF5GalaxyWriter::write_galaxies(hdf5::Writer &file, int snapshot, const st
 	REPORT(mstars_metals_burst_diskinstabilities);
 	REPORT(mstars_metals_bulge_mergers_assembly);
 	REPORT(mstars_metals_bulge_diskins_assembly);
+	REPORT(mstars_metals_stripped);
 	REPORT(mean_stellar_age);
 	REPORT(mgas_metals_disk);
 	REPORT(mgas_metals_bulge);
@@ -573,6 +589,8 @@ void HDF5GalaxyWriter::write_galaxies(hdf5::Writer &file, int snapshot, const st
 	REPORT(mreheated_metals);
 	REPORT(mlost);
 	REPORT(mlost_metals);
+	REPORT(stellar_halo);
+	REPORT(stellar_halo_metals);
 	REPORT(cooling_rate);
 	REPORT(mvir_hosthalo);
 	REPORT(mvir_subhalo);
@@ -675,6 +693,9 @@ void HDF5GalaxyWriter::write_galaxies(hdf5::Writer &file, int snapshot, const st
 	comment = "stellar mass in the bulge brought via disk instabilities from the disk [Msun/h]";
 	file.write_dataset("galaxies/mstars_bulge_diskins_assembly", mstars_bulge_diskins_assembly, comment);
 
+	comment = "stellar mass that was tidally stripped from this galaxy [Msun/h]";
+	file.write_dataset("galaxies/mstars_tidally_stripped", mstars_stripped, comment);
+
 	comment = "total gas mass in the disk [Msun/h]";
 	file.write_dataset("galaxies/mgas_disk", mgas_disk, comment);
 
@@ -698,6 +719,9 @@ void HDF5GalaxyWriter::write_galaxies(hdf5::Writer &file, int snapshot, const st
 
 	comment = "mass of metals locked in stars in the bulge that was brought via disk instabilities from the disk [Msun/h]";
 	file.write_dataset("galaxies/mstars_metals_bulge_diskins_assembly", mstars_metals_bulge_diskins_assembly, comment);
+
+	comment = "mass of metals locked in stars that was tidally stripped from this galaxy [Msun/h]";
+	file.write_dataset("galaxies/mstars_metals_tidally_stripped", mstars_metals_stripped, comment);
 
 	comment = "stellar mass-weighted stellar age [Gyr]";
 	file.write_dataset("galaxies/mean_stellar_age", mean_stellar_age, comment);
@@ -785,6 +809,12 @@ void HDF5GalaxyWriter::write_galaxies(hdf5::Writer &file, int snapshot, const st
 
 	comment = "mass of metals locked in the lost gas component - due to QSO feedback [Msun/h]";
 	file.write_dataset("galaxies/mlost_metals", mlost_metals, comment);
+
+	comment = "stellar mass in the halo built by tidal stripping [Msun/h]";
+	file.write_dataset("galaxies/mstellar_halo", stellar_halo, comment);
+
+	comment = "mass of metals locked up in the stellar halo built by tidal stripping [Msun/h]";
+	file.write_dataset("galaxies/mstellar_halo_metals", stellar_halo_metals, comment);
 
 	comment = "cooling rate of the hot halo component [Msun/Gyr/h].";
 	file.write_dataset("galaxies/cooling_rate", cooling_rate, comment);

--- a/src/tree_builder.cpp
+++ b/src/tree_builder.cpp
@@ -439,6 +439,7 @@ void TreeBuilder::define_ages_halos(const std::vector<MergerTreePtr> &trees, Sim
 						while(main_prog && subhalo->infall_t == 0){
 							if(main_prog->subhalo_type == Subhalo::CENTRAL){
 								subhalo->infall_t = sim_params.redshifts[snap];
+								subhalo->Mvir_infall = main_prog->Mvir;
 							}
 							snap --;
 							main_prog = main_prog->main();


### PR DESCRIPTION
This new model is based on the calculations of Errani et al. (2015),
which modelled the tidal stripping of satellite galaxies in a Milky-Way
halo. The outcome of the simulations were fit and here I adopt the best
fit for a cuspy core with an r_star/a=0.1. This seems to have the
desired effect on the stellar mass function.

There is a free parameter which is the minimum allowed threshold of
virial mass ratio (Mvir,now/Mvir,infall), which is relevant for galaxies
that go from centrals to becoming type II without ever becoming type 1.
If the more normal scenario of central->type I->type II takes place,
then tidal stripping is more gradual (as it depends on the virial mass
loss).