### PR TITLE
Export environment variables through sbatch

### DIFF
--- a/hpc/shark-submit
+++ b/hpc/shark-submit
@@ -231,7 +231,7 @@ print_usage() {
 submit_slurm() {
 
 	# Each SHArk instance will be ran as a task
-	cmd="sbatch --ntasks $n_tasks"
+	cmd="sbatch --export ALL --ntasks $n_tasks"
 	cmd="$cmd -o shark-run.log"
 
 	# Get the ID of the new job


### PR DESCRIPTION
In some environments (e.g., Magnus now, but wasn't the case before)
environment variables are not always exported from the user's
environment into the job execution. This breaks one of the key
assumptions of the interaction between shark-submit and shark-run, in
that the latter works only because the former exports certain
environment variables. It also caused problems with the module system,
as (again in Magnus, but maybe in other systems as well) users need to
perform a `module switch` command before submitting in order to
correctly load the appropriate runtime modules.

Signed-off-by: Rodrigo Tobar <rtobar@icrar.org>