### PR TITLE
Bump dependency on Boost to >= 1.68

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,7 @@ macro(find_boost)
 	# with homebrew). Let's thus not use Boost's cmake config file and stick to
 	# cmake's own version of it for the time being
 	set(Boost_NO_BOOST_CMAKE ON)
-	find_package(Boost 1.54 COMPONENTS filesystem log program_options system REQUIRED)
+	find_package(Boost 1.68 COMPONENTS filesystem log program_options system REQUIRED)
 	set(SHARK_LIBS ${SHARK_LIBS} ${Boost_LIBRARIES})
 	include_directories(${Boost_INCLUDE_DIRS})
 endmacro()

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -19,7 +19,7 @@ Requirements
 
 * `GSL <https://www.gnu.org/software/gsl/>`_ >= 2.0
 * `HDF5 <https://support.hdfgroup.org/HDF5/>`_ >= 1.8.0
-* `Boost <http://www.boost.org/>`_ >= 1.54
+* `Boost <http://www.boost.org/>`_ >= 1.68
 
 Optional requirements are:
 


### PR DESCRIPTION
We used to depend on >= 1.54, but in a8096298 we accidentally raised the minimum required Boost version to 1.68 (boost::optional::has_value() was introduced in that version to align with std::optional). This version of Boost is 5 years old though, so instead of modifying our code to cope with older versions, we're probably better off declaring a higher minimum version.

This was the original cause of #13, and thus it should prevent this issue from happening again in the near future.